### PR TITLE
Keep track of the fhir path while traversing for better errors.

### DIFF
--- a/src/fhir-tool-conversion/BaseConverter.cs
+++ b/src/fhir-tool-conversion/BaseConverter.cs
@@ -20,8 +20,10 @@ namespace FhirTool.Conversion
         protected abstract void InitComponentTypeMap();
 
         public abstract Type GetTargetCodeType();
-
         public abstract Type GetSourceCodeType();
+        public abstract Type GetTargetFhirElementAttribute();
+        public abstract Type GetSourceFhirElementAttribute();
+
         protected abstract string GetFhirTypeNameForTargetType(Type targetType);
 
         protected abstract Type GetTargetTypeForFhirTypeName(string targetTypeName);
@@ -72,14 +74,14 @@ namespace FhirTool.Conversion
             return GetSourceFhirType(type) != null;
         }
 
-        public void Convert(FhirConverter converter, Base to, Base from)
+        public void Convert(Base to, Base from, FhirConverter converter)
         {
             var toType = to.GetType();
             var fromType = from.GetType();
             var key = (toType, fromType);
             if (Map.TryGetValue(key, out var convert))
             {
-                convert.DynamicInvoke(converter, to, from);
+                convert.DynamicInvoke(to, from, converter);
             }
         }
 

--- a/src/fhir-tool-conversion/BaseConverter.cs
+++ b/src/fhir-tool-conversion/BaseConverter.cs
@@ -21,8 +21,8 @@ namespace FhirTool.Conversion
 
         public abstract Type GetTargetCodeType();
         public abstract Type GetSourceCodeType();
-        public abstract Type GetTargetFhirElementAttribute();
-        public abstract Type GetSourceFhirElementAttribute();
+        public abstract Type GetTargetFhirElementAttributeType();
+        public abstract Type GetSourceFhirElementAttributeType();
 
         protected abstract string GetFhirTypeNameForTargetType(Type targetType);
 

--- a/src/fhir-tool-conversion/Converters/FhirR3ToR4ConversionRoutines.cs
+++ b/src/fhir-tool-conversion/Converters/FhirR3ToR4ConversionRoutines.cs
@@ -66,7 +66,7 @@ namespace FhirTool.Conversion.Converters
             if (from != null)
             {
                 to.CurrencyElement = ConvertCodeToCodeMoney(from.CodeElement, converter);
-                to.ValueElement = converter.ConvertObject<TargetModel.FhirDecimal, SourceModel.FhirDecimal>(from.ValueElement);
+                to.ValueElement = converter.ConvertElement<TargetModel.FhirDecimal, SourceModel.FhirDecimal>(from.ValueElement);
             }
         }
 
@@ -161,7 +161,7 @@ namespace FhirTool.Conversion.Converters
             {
                 if (from.Who is SourceModel.ResourceReference fromResourceReference)
                 {
-                    to.Who = converter.ConvertObject<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
+                    to.Who = converter.ConvertElement<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
                 }
                 else if (from.Who is SourceModel.FhirUri fromFhirUri)
                 {
@@ -173,7 +173,7 @@ namespace FhirTool.Conversion.Converters
             {
                 if (from.OnBehalfOf is SourceModel.ResourceReference fromResourceReference)
                 {
-                    to.OnBehalfOf = converter.ConvertObject<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
+                    to.OnBehalfOf = converter.ConvertElement<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
                 }
                 else if (from.OnBehalfOf is SourceModel.FhirUri fromFhirUri)
                 {
@@ -192,11 +192,11 @@ namespace FhirTool.Conversion.Converters
         {
             if (from.Dose != null)
             {
-                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Dose = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Dose) });
+                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Dose = converter.ConvertElement<TargetModel.Element, SourceModel.Element>(from.Dose) });
             }
             if (from.Rate != null)
             {
-                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Rate = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Rate) });
+                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Rate = converter.ConvertElement<TargetModel.Element, SourceModel.Element>(from.Rate) });
             }
         }
 
@@ -227,7 +227,7 @@ namespace FhirTool.Conversion.Converters
         {
             return new TargetModel.Questionnaire.InitialComponent
             {
-                Value = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from),
+                Value = converter.ConvertElement<TargetModel.Element, SourceModel.Element>(from),
             };
         }
 

--- a/src/fhir-tool-conversion/Converters/FhirR3ToR4ConversionRoutines.cs
+++ b/src/fhir-tool-conversion/Converters/FhirR3ToR4ConversionRoutines.cs
@@ -37,18 +37,18 @@ namespace FhirTool.Conversion.Converters
             Map.Add<TargetModel.Dosage, SourceModel.Dosage>(ConvertDosage);
         }
 
-        private static void ConvertQuestionnaireResponse(FhirConverter converter, TargetModel.QuestionnaireResponse to, SourceModel.QuestionnaireResponse from)
+        private static void ConvertQuestionnaireResponse(TargetModel.QuestionnaireResponse to, SourceModel.QuestionnaireResponse from, FhirConverter converter)
         {
             to.QuestionnaireElement = ConvertResourceReferenceToCanonical(from.Questionnaire, converter);
         }
 
-        private static void ConvertQuestionnaireItemComponent(FhirConverter converter, TargetModel.Questionnaire.ItemComponent to, SourceModel.Questionnaire.ItemComponent from)
+        private static void ConvertQuestionnaireItemComponent(TargetModel.Questionnaire.ItemComponent to, SourceModel.Questionnaire.ItemComponent from, FhirConverter converter)
         {
             to.Initial = from.Initial == null ? to.Initial : new List<TargetModel.Questionnaire.InitialComponent> { ConvertElementToInitialComponent(from.Initial, converter) };
             to.AnswerValueSetElement = ConvertResourceReferenceToCanonical(from.Options, converter);
         }
 
-        private static void ConvertQuestionnaireEnableWhenComponent(FhirConverter converter, TargetModel.Questionnaire.EnableWhenComponent to, SourceModel.Questionnaire.EnableWhenComponent from)
+        private static void ConvertQuestionnaireEnableWhenComponent(TargetModel.Questionnaire.EnableWhenComponent to, SourceModel.Questionnaire.EnableWhenComponent from, FhirConverter converter)
         {
             if (from.HasAnswer.HasValue)
             {
@@ -61,33 +61,33 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertMoney(FhirConverter converter, TargetModel.Money to, SourceModel.Money from)
+        private static void ConvertMoney(TargetModel.Money to, SourceModel.Money from, FhirConverter converter)
         {
             if (from != null)
             {
                 to.CurrencyElement = ConvertCodeToCodeMoney(from.CodeElement, converter);
-                to.ValueElement = converter.Convert<TargetModel.FhirDecimal, SourceModel.FhirDecimal>(from.ValueElement);
+                to.ValueElement = converter.ConvertObject<TargetModel.FhirDecimal, SourceModel.FhirDecimal>(from.ValueElement);
             }
         }
 
-        private static void ConvertAttachment(FhirConverter converter, TargetModel.Attachment to, SourceModel.Attachment from)
+        private static void ConvertAttachment(TargetModel.Attachment to, SourceModel.Attachment from, FhirConverter converter)
         {
             to.UrlElement = ConvertFhirUriToFhirUrl(from.UrlElement, converter);
         }
 
-        private static void ConvertRelatedArtifact(FhirConverter converter, TargetModel.RelatedArtifact to, SourceModel.RelatedArtifact from)
+        private static void ConvertRelatedArtifact(TargetModel.RelatedArtifact to, SourceModel.RelatedArtifact from, FhirConverter converter)
         {
             to.UrlElement = ConvertFhirUriToFhirUrl(from.UrlElement, converter);
             to.Citation = ConvertFhirStringToMarkdown(from.CitationElement, converter);
             to.ResourceElement = ConvertResourceReferenceToCanonical(from.Resource, converter);
         }
 
-        private static void ConvertDataRequirement(FhirConverter converter, TargetModel.DataRequirement to, SourceModel.DataRequirement from)
+        private static void ConvertDataRequirement(TargetModel.DataRequirement to, SourceModel.DataRequirement from, FhirConverter converter)
         {
             to.ProfileElement = from.ProfileElement.Select(e => ConvertFhirUriToCanonical(e, converter)).ToList();
         }
 
-        private static void ConvertDataRequirementCodeFilterComponent(FhirConverter converter, TargetModel.DataRequirement.CodeFilterComponent to, SourceModel.DataRequirement.CodeFilterComponent from)
+        private static void ConvertDataRequirementCodeFilterComponent(TargetModel.DataRequirement.CodeFilterComponent to, SourceModel.DataRequirement.CodeFilterComponent from, FhirConverter converter)
         {
             if (from.ValueSet is SourceModel.ResourceReference fromResourceReference)
             {
@@ -99,23 +99,23 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertMeta(FhirConverter converter, TargetModel.Meta to, SourceModel.Meta from)
+        private static void ConvertMeta(TargetModel.Meta to, SourceModel.Meta from, FhirConverter converter)
         {
             to.ProfileElement = from.ProfileElement.Select(e => ConvertFhirUriToCanonical(e, converter)).ToList();
         }
 
-        private static void ConvertElementDefinitionTypeRefComponent(FhirConverter converter, TargetModel.ElementDefinition.TypeRefComponent to, SourceModel.ElementDefinition.TypeRefComponent from)
+        private static void ConvertElementDefinitionTypeRefComponent(TargetModel.ElementDefinition.TypeRefComponent to, SourceModel.ElementDefinition.TypeRefComponent from, FhirConverter converter)
         {
             to.ProfileElement = from.ProfileElement == null ? to.ProfileElement : new List<TargetModel.Canonical> { ConvertFhirUriToCanonical(from.ProfileElement, converter) };
             to.TargetProfileElement = from.TargetProfileElement == null ? to.TargetProfileElement : new List<TargetModel.Canonical> { ConvertFhirUriToCanonical(from.TargetProfileElement, converter) };
         }
 
-        private static void ConvertElementDefinitionConstraintComponent(FhirConverter converter, TargetModel.ElementDefinition.ConstraintComponent to, SourceModel.ElementDefinition.ConstraintComponent from)
+        private static void ConvertElementDefinitionConstraintComponent(TargetModel.ElementDefinition.ConstraintComponent to, SourceModel.ElementDefinition.ConstraintComponent from, FhirConverter converter)
         {
             to.SourceElement = ConvertFhirUriToCanonical(from.SourceElement, converter);
         }
 
-        private static void ConvertElementDefinitionBindingComponent(FhirConverter converter, TargetModel.ElementDefinition.ElementDefinitionBindingComponent to, SourceModel.ElementDefinition.ElementDefinitionBindingComponent from)
+        private static void ConvertElementDefinitionBindingComponent(TargetModel.ElementDefinition.ElementDefinitionBindingComponent to, SourceModel.ElementDefinition.ElementDefinitionBindingComponent from, FhirConverter converter)
         {
             if (from.ValueSet is SourceModel.FhirUri fromFhirUri)
             {
@@ -127,22 +127,22 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertValueSetConceptSetComponent(FhirConverter converter, TargetModel.ValueSet.ConceptSetComponent to, SourceModel.ValueSet.ConceptSetComponent from)
+        private static void ConvertValueSetConceptSetComponent(TargetModel.ValueSet.ConceptSetComponent to, SourceModel.ValueSet.ConceptSetComponent from, FhirConverter converter)
         {
             to.ValueSetElement = from.ValueSetElement.Select(e => ConvertFhirUriToCanonical(e, converter)).ToList();
         }
 
-        private static void ConvertValueSetFilterComponent(FhirConverter converter, TargetModel.ValueSet.FilterComponent to, SourceModel.ValueSet.FilterComponent from)
+        private static void ConvertValueSetFilterComponent(TargetModel.ValueSet.FilterComponent to, SourceModel.ValueSet.FilterComponent from, FhirConverter converter)
         {
             to.ValueElement = ConvertCodeToFhirString(from.ValueElement, converter);
         }
 
-        private static void ConvertAnnotation(FhirConverter converter, TargetModel.Annotation to, SourceModel.Annotation from)
+        private static void ConvertAnnotation(TargetModel.Annotation to, SourceModel.Annotation from, FhirConverter converter)
         {
             to.Text = ConvertFhirStringToMarkdown(from.TextElement, converter);
         }
 
-        private static void ConvertTimingRepeatComponent(FhirConverter converter, TargetModel.Timing.RepeatComponent to, SourceModel.Timing.RepeatComponent from)
+        private static void ConvertTimingRepeatComponent(TargetModel.Timing.RepeatComponent to, SourceModel.Timing.RepeatComponent from, FhirConverter converter)
         {
             to.CountElement = ConvertIntegerToPositiveInt(from.CountElement, converter);
             to.CountMaxElement = ConvertIntegerToPositiveInt(from.CountMaxElement, converter);
@@ -150,18 +150,18 @@ namespace FhirTool.Conversion.Converters
             to.FrequencyMaxElement = ConvertIntegerToPositiveInt(from.FrequencyMaxElement, converter);
         }
 
-        private static void ConvertParameterDefinition(FhirConverter converter, TargetModel.ParameterDefinition to, SourceModel.ParameterDefinition from)
+        private static void ConvertParameterDefinition(TargetModel.ParameterDefinition to, SourceModel.ParameterDefinition from, FhirConverter converter)
         {
             to.ProfileElement = ConvertResourceReferenceToCanonical(from.Profile, converter);
         }
 
-        private static void ConvertSignature(FhirConverter converter, TargetModel.Signature to, SourceModel.Signature from)
+        private static void ConvertSignature(TargetModel.Signature to, SourceModel.Signature from, FhirConverter converter)
         {
             if (from.Who != null)
             {
                 if (from.Who is SourceModel.ResourceReference fromResourceReference)
                 {
-                    to.Who = converter.Convert<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
+                    to.Who = converter.ConvertObject<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
                 }
                 else if (from.Who is SourceModel.FhirUri fromFhirUri)
                 {
@@ -173,7 +173,7 @@ namespace FhirTool.Conversion.Converters
             {
                 if (from.OnBehalfOf is SourceModel.ResourceReference fromResourceReference)
                 {
-                    to.OnBehalfOf = converter.Convert<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
+                    to.OnBehalfOf = converter.ConvertObject<TargetModel.ResourceReference, SourceModel.ResourceReference>(fromResourceReference);
                 }
                 else if (from.OnBehalfOf is SourceModel.FhirUri fromFhirUri)
                 {
@@ -182,21 +182,21 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertRange(FhirConverter converter, TargetModel.Range to, SourceModel.Range from)
+        private static void ConvertRange(TargetModel.Range to, SourceModel.Range from, FhirConverter converter)
         {
             to.High = ConvertQuantityToSimpleQuantity(from.High, converter);
             to.Low = ConvertQuantityToSimpleQuantity(from.Low, converter);
         }
 
-        private static void ConvertDosage(FhirConverter converter, TargetModel.Dosage to, SourceModel.Dosage from)
+        private static void ConvertDosage(TargetModel.Dosage to, SourceModel.Dosage from, FhirConverter converter)
         {
             if (from.Dose != null)
             {
-                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Dose = converter.Convert<TargetModel.Element, SourceModel.Element>(from.Dose) });
+                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Dose = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Dose) });
             }
             if (from.Rate != null)
             {
-                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Rate = converter.Convert<TargetModel.Element, SourceModel.Element>(from.Rate) });
+                to.DoseAndRate.Add(new TargetModel.Dosage.DoseAndRateComponent { Rate = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Rate) });
             }
         }
 
@@ -208,7 +208,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Code<TargetModel.Money.Currencies>
             {
                 Value = string.IsNullOrEmpty(from.Value) ? null : EnumUtility.ParseLiteral<TargetModel.Money.Currencies>(from.Value),
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -219,7 +219,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.FhirUrl
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -227,7 +227,7 @@ namespace FhirTool.Conversion.Converters
         {
             return new TargetModel.Questionnaire.InitialComponent
             {
-                Value = converter.Convert<TargetModel.Element, SourceModel.Element>(from),
+                Value = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from),
             };
         }
 
@@ -238,7 +238,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Canonical
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -249,7 +249,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Canonical
             {
                 Value = from.Reference,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -260,7 +260,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Canonical
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -271,7 +271,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Markdown
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -282,7 +282,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.FhirString
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -293,7 +293,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.ResourceReference
             {
                 Reference = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -304,7 +304,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.PositiveInt
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -318,7 +318,7 @@ namespace FhirTool.Conversion.Converters
                 Code = from.Code,
                 Value = from.Value,
                 Unit = from.Unit,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
     }

--- a/src/fhir-tool-conversion/Converters/FhirR4ToR3ConversionRoutines.cs
+++ b/src/fhir-tool-conversion/Converters/FhirR4ToR3ConversionRoutines.cs
@@ -34,18 +34,18 @@ namespace FhirTool.Conversion.Converters
             Map.Add<TargetModel.Dosage, SourceModel.Dosage>(ConvertDosage);
         }
 
-        private static void ConvertQuestionnaireResponse(FhirConverter converter, TargetModel.QuestionnaireResponse to, SourceModel.QuestionnaireResponse from)
+        private static void ConvertQuestionnaireResponse(TargetModel.QuestionnaireResponse to, SourceModel.QuestionnaireResponse from, FhirConverter converter)
         {
             to.Questionnaire = new TargetModel.ResourceReference(from.Questionnaire);
         }
 
-        private static void ConvertQuestionnaireItemComponent(FhirConverter converter, TargetModel.Questionnaire.ItemComponent to, SourceModel.Questionnaire.ItemComponent from)
+        private static void ConvertQuestionnaireItemComponent(TargetModel.Questionnaire.ItemComponent to, SourceModel.Questionnaire.ItemComponent from, FhirConverter converter)
         {
-            to.Initial = converter.Convert<TargetModel.Element, SourceModel.Element>(from.Initial.FirstOrDefault()?.Value);
+            to.Initial = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Initial.FirstOrDefault()?.Value);
             to.Options = ConvertCanonicalToResourceReference(from.AnswerValueSetElement, converter);
         }
 
-        private static void ConvertQuestionnaireEnableWhenComponent(FhirConverter converter, TargetModel.Questionnaire.EnableWhenComponent to, SourceModel.Questionnaire.EnableWhenComponent from)
+        private static void ConvertQuestionnaireEnableWhenComponent(TargetModel.Questionnaire.EnableWhenComponent to, SourceModel.Questionnaire.EnableWhenComponent from, FhirConverter converter)
         {
             if (from.Operator == SourceModel.Questionnaire.QuestionnaireItemOperator.Exists && from.Answer is SourceModel.FhirBoolean answer)
             {
@@ -53,7 +53,7 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertMoney(FhirConverter converter, TargetModel.Money to, SourceModel.Money from)
+        private static void ConvertMoney(TargetModel.Money to, SourceModel.Money from, FhirConverter converter)
         {
             if (from.Currency.HasValue)
             {
@@ -61,70 +61,70 @@ namespace FhirTool.Conversion.Converters
                 to.CodeElement = new TargetModel.Code
                 {
                     Value = from.Currency.Value.GetLiteral(),
-                    Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                    Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
                 };
             }
         }
 
-        private static void ConvertAttachment(FhirConverter converter, TargetModel.Attachment to, SourceModel.Attachment from)
+        private static void ConvertAttachment(TargetModel.Attachment to, SourceModel.Attachment from, FhirConverter converter)
         {
             to.UrlElement = ConvertFhirUrlToFhirUri(from.UrlElement, converter);
         }
 
-        private static void ConvertRelatedArtifact(FhirConverter converter, TargetModel.RelatedArtifact to, SourceModel.RelatedArtifact from)
+        private static void ConvertRelatedArtifact(TargetModel.RelatedArtifact to, SourceModel.RelatedArtifact from, FhirConverter converter)
         {
             to.UrlElement = ConvertFhirUrlToFhirUri(from.UrlElement, converter);
             to.CitationElement = ConvertMarkdownToFhirString(from.Citation, converter);
             to.Resource = ConvertCanonicalToResourceReference(from.ResourceElement, converter);
         }
 
-        private static void ConvertDataRequirement(FhirConverter converter, TargetModel.DataRequirement to, SourceModel.DataRequirement from)
+        private static void ConvertDataRequirement(TargetModel.DataRequirement to, SourceModel.DataRequirement from, FhirConverter converter)
         {
             to.ProfileElement = from.ProfileElement.Select(e => ConvertCanonicalToFhirUri(e, converter)).ToList();
         }
 
-        private static void ConvertDataRequirementCodeFilterComponent(FhirConverter converter, TargetModel.DataRequirement.CodeFilterComponent to, SourceModel.DataRequirement.CodeFilterComponent from)
+        private static void ConvertDataRequirementCodeFilterComponent(TargetModel.DataRequirement.CodeFilterComponent to, SourceModel.DataRequirement.CodeFilterComponent from, FhirConverter converter)
         {
             to.ValueSet = ConvertCanonicalToResourceReference(from.ValueSetElement, converter);
         }
 
-        private static void ConvertMeta(FhirConverter converter, TargetModel.Meta to, SourceModel.Meta from)
+        private static void ConvertMeta(TargetModel.Meta to, SourceModel.Meta from, FhirConverter converter)
         {
             to.ProfileElement = from.ProfileElement.Select(e => ConvertCanonicalToFhirUri(e, converter)).ToList();
         }
 
-        private static void ConvertElementDefinitionTypeRefComponent(FhirConverter converter, TargetModel.ElementDefinition.TypeRefComponent to, SourceModel.ElementDefinition.TypeRefComponent from)
+        private static void ConvertElementDefinitionTypeRefComponent(TargetModel.ElementDefinition.TypeRefComponent to, SourceModel.ElementDefinition.TypeRefComponent from, FhirConverter converter)
         {
             to.ProfileElement = ConvertCanonicalToFhirUri(from.ProfileElement.FirstOrDefault(), converter);
             to.TargetProfileElement = ConvertCanonicalToFhirUri(from.TargetProfileElement.FirstOrDefault(), converter);
         }
 
-        private static void ConvertElementDefinitionConstraintComponent(FhirConverter converter, TargetModel.ElementDefinition.ConstraintComponent to, SourceModel.ElementDefinition.ConstraintComponent from)
+        private static void ConvertElementDefinitionConstraintComponent(TargetModel.ElementDefinition.ConstraintComponent to, SourceModel.ElementDefinition.ConstraintComponent from, FhirConverter converter)
         {
             to.SourceElement = ConvertCanonicalToFhirUri(from.SourceElement, converter);
         }
 
-        private static void ConvertElementDefinitionBindingComponent(FhirConverter converter, TargetModel.ElementDefinition.ElementDefinitionBindingComponent to, SourceModel.ElementDefinition.ElementDefinitionBindingComponent from)
+        private static void ConvertElementDefinitionBindingComponent(TargetModel.ElementDefinition.ElementDefinitionBindingComponent to, SourceModel.ElementDefinition.ElementDefinitionBindingComponent from, FhirConverter converter)
         {
             to.ValueSet = ConvertCanonicalToResourceReference(from.ValueSetElement, converter);
         }
 
-        private static void ConvertValueSetConceptSetComponent(FhirConverter converter, TargetModel.ValueSet.ConceptSetComponent to, SourceModel.ValueSet.ConceptSetComponent from)
+        private static void ConvertValueSetConceptSetComponent(TargetModel.ValueSet.ConceptSetComponent to, SourceModel.ValueSet.ConceptSetComponent from, FhirConverter converter)
         {
             to.ValueSetElement = from.ValueSetElement.Select(e => ConvertCanonicalToFhirUri(e, converter)).ToList();
         }
 
-        private static void ConvertValueSetFilterComponent(FhirConverter converter, TargetModel.ValueSet.FilterComponent to, SourceModel.ValueSet.FilterComponent from)
+        private static void ConvertValueSetFilterComponent(TargetModel.ValueSet.FilterComponent to, SourceModel.ValueSet.FilterComponent from, FhirConverter converter)
         {
             to.ValueElement = ConvertFhirStringToCode(from.ValueElement, converter);
         }
 
-        private static void ConvertAnnotation(FhirConverter converter, TargetModel.Annotation to, SourceModel.Annotation from)
+        private static void ConvertAnnotation(TargetModel.Annotation to, SourceModel.Annotation from, FhirConverter converter)
         {
             to.TextElement = ConvertMarkdownToFhirString(from.Text, converter);
         }
 
-        private static void ConvertTimingRepeatComponent(FhirConverter converter, TargetModel.Timing.RepeatComponent to, SourceModel.Timing.RepeatComponent from)
+        private static void ConvertTimingRepeatComponent(TargetModel.Timing.RepeatComponent to, SourceModel.Timing.RepeatComponent from, FhirConverter converter)
         {
             to.CountElement = ConvertPositiveIntToInteger(from.CountElement, converter);
             to.CountMaxElement = ConvertPositiveIntToInteger(from.CountMaxElement, converter);
@@ -132,18 +132,18 @@ namespace FhirTool.Conversion.Converters
             to.FrequencyMaxElement = ConvertPositiveIntToInteger(from.FrequencyMaxElement, converter);
         }
 
-        private static void ConvertParameterDefinition(FhirConverter converter, TargetModel.ParameterDefinition to, SourceModel.ParameterDefinition from)
+        private static void ConvertParameterDefinition(TargetModel.ParameterDefinition to, SourceModel.ParameterDefinition from, FhirConverter converter)
         {
             to.Profile = ConvertCanonicalToResourceReference(from.ProfileElement, converter);
         }
 
-        private static void ConvertDosage(FhirConverter converter, TargetModel.Dosage to, SourceModel.Dosage from)
+        private static void ConvertDosage(TargetModel.Dosage to, SourceModel.Dosage from, FhirConverter converter)
         {
             var fromDose = from.DoseAndRate.FirstOrDefault(it => it.Dose != null);
             var fromRate = from.DoseAndRate.FirstOrDefault(it => it.Rate != null);
 
-            to.Dose = fromDose == null ? to.Dose : converter.Convert<TargetModel.Element, SourceModel.Element>(fromDose);
-            to.Rate = fromRate == null ? to.Rate : converter.Convert<TargetModel.Element, SourceModel.Element>(fromRate);
+            to.Dose = fromDose == null ? to.Dose : converter.ConvertObject<TargetModel.Element, SourceModel.Element>(fromDose);
+            to.Rate = fromRate == null ? to.Rate : converter.ConvertObject<TargetModel.Element, SourceModel.Element>(fromRate);
         }
 
         // Helpers
@@ -154,7 +154,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Code
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -165,7 +165,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.FhirUri
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -176,7 +176,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.FhirUri
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -187,7 +187,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.FhirString
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -198,7 +198,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.Integer
             {
                 Value = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
 
@@ -209,7 +209,7 @@ namespace FhirTool.Conversion.Converters
             return new TargetModel.ResourceReference
             {
                 Reference = from.Value,
-                Extension = converter.Convert<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
+                Extension = converter.ConvertList<TargetModel.Extension, SourceModel.Extension>(from.Extension).ToList()
             };
         }
     }

--- a/src/fhir-tool-conversion/Converters/FhirR4ToR3ConversionRoutines.cs
+++ b/src/fhir-tool-conversion/Converters/FhirR4ToR3ConversionRoutines.cs
@@ -41,7 +41,7 @@ namespace FhirTool.Conversion.Converters
 
         private static void ConvertQuestionnaireItemComponent(TargetModel.Questionnaire.ItemComponent to, SourceModel.Questionnaire.ItemComponent from, FhirConverter converter)
         {
-            to.Initial = converter.ConvertObject<TargetModel.Element, SourceModel.Element>(from.Initial.FirstOrDefault()?.Value);
+            to.Initial = converter.ConvertElement<TargetModel.Element, SourceModel.Element>(from.Initial.FirstOrDefault()?.Value);
             to.Options = ConvertCanonicalToResourceReference(from.AnswerValueSetElement, converter);
         }
 
@@ -142,8 +142,8 @@ namespace FhirTool.Conversion.Converters
             var fromDose = from.DoseAndRate.FirstOrDefault(it => it.Dose != null);
             var fromRate = from.DoseAndRate.FirstOrDefault(it => it.Rate != null);
 
-            to.Dose = fromDose == null ? to.Dose : converter.ConvertObject<TargetModel.Element, SourceModel.Element>(fromDose);
-            to.Rate = fromRate == null ? to.Rate : converter.ConvertObject<TargetModel.Element, SourceModel.Element>(fromRate);
+            to.Dose = fromDose == null ? to.Dose : converter.ConvertElement<TargetModel.Element, SourceModel.Element>(fromDose);
+            to.Rate = fromRate == null ? to.Rate : converter.ConvertElement<TargetModel.Element, SourceModel.Element>(fromRate);
         }
 
         // Helpers

--- a/src/fhir-tool-conversion/Converters/Support/FhirR3ToR4ConversionSupport.cs
+++ b/src/fhir-tool-conversion/Converters/Support/FhirR3ToR4ConversionSupport.cs
@@ -4,8 +4,11 @@ extern alias R4;
 using System;
 using FhirTool.Conversion.Converters.Support.TypeMaps;
 
-using SourceModel = R3::Hl7.Fhir.Model;
 using TargetModel = R4::Hl7.Fhir.Model;
+using SourceModel = R3::Hl7.Fhir.Model;
+
+using TargetIntrospection = R4::Hl7.Fhir.Introspection;
+using SourceIntrospection = R3::Hl7.Fhir.Introspection;
 
 namespace FhirTool.Conversion.Converters
 {
@@ -25,6 +28,16 @@ namespace FhirTool.Conversion.Converters
         public override Type GetSourceCodeType()
         {
             return typeof(SourceModel.Code<>);
+        }
+
+        public override Type GetTargetFhirElementAttribute()
+        {
+            return typeof(TargetIntrospection.FhirElementAttribute);
+        }
+
+        public override Type GetSourceFhirElementAttribute()
+        {
+            return typeof(SourceIntrospection.FhirElementAttribute);
         }
 
         protected override string GetFhirTypeNameForTargetType(Type targetType)

--- a/src/fhir-tool-conversion/Converters/Support/FhirR3ToR4ConversionSupport.cs
+++ b/src/fhir-tool-conversion/Converters/Support/FhirR3ToR4ConversionSupport.cs
@@ -30,12 +30,12 @@ namespace FhirTool.Conversion.Converters
             return typeof(SourceModel.Code<>);
         }
 
-        public override Type GetTargetFhirElementAttribute()
+        public override Type GetTargetFhirElementAttributeType()
         {
             return typeof(TargetIntrospection.FhirElementAttribute);
         }
 
-        public override Type GetSourceFhirElementAttribute()
+        public override Type GetSourceFhirElementAttributeType()
         {
             return typeof(SourceIntrospection.FhirElementAttribute);
         }

--- a/src/fhir-tool-conversion/Converters/Support/FhirR4ToR3ConversionSupport.cs
+++ b/src/fhir-tool-conversion/Converters/Support/FhirR4ToR3ConversionSupport.cs
@@ -7,6 +7,9 @@ using FhirTool.Conversion.Converters.Support.TypeMaps;
 using TargetModel = R3::Hl7.Fhir.Model;
 using SourceModel = R4::Hl7.Fhir.Model;
 
+using TargetIntrospection = R3::Hl7.Fhir.Introspection;
+using SourceIntrospection = R4::Hl7.Fhir.Introspection;
+
 namespace FhirTool.Conversion.Converters
 {
     internal partial class FhirR4ToR3ConversionRoutines : BaseConverter
@@ -25,6 +28,16 @@ namespace FhirTool.Conversion.Converters
         public override Type GetSourceCodeType()
         {
             return typeof(SourceModel.Code<>);
+        }
+
+        public override Type GetTargetFhirElementAttribute()
+        {
+            return typeof(TargetIntrospection.FhirElementAttribute);
+        }
+
+        public override Type GetSourceFhirElementAttribute()
+        {
+            return typeof(SourceIntrospection.FhirElementAttribute);
         }
 
         protected override string GetFhirTypeNameForTargetType(Type targetType)

--- a/src/fhir-tool-conversion/Converters/Support/FhirR4ToR3ConversionSupport.cs
+++ b/src/fhir-tool-conversion/Converters/Support/FhirR4ToR3ConversionSupport.cs
@@ -30,12 +30,12 @@ namespace FhirTool.Conversion.Converters
             return typeof(SourceModel.Code<>);
         }
 
-        public override Type GetTargetFhirElementAttribute()
+        public override Type GetTargetFhirElementAttributeType()
         {
             return typeof(TargetIntrospection.FhirElementAttribute);
         }
 
-        public override Type GetSourceFhirElementAttribute()
+        public override Type GetSourceFhirElementAttributeType()
         {
             return typeof(SourceIntrospection.FhirElementAttribute);
         }

--- a/src/fhir-tool-conversion/DictionaryExtensions.cs
+++ b/src/fhir-tool-conversion/DictionaryExtensions.cs
@@ -6,7 +6,7 @@ namespace FhirTool.Conversion
 {
     public static class DictionaryExtensions
     {
-        public static void Add<TTo, TFrom>(this Dictionary<(Type, Type), Delegate> me, Action<FhirConverter, TTo, TFrom> func)
+        public static void Add<TTo, TFrom>(this Dictionary<(Type, Type), Delegate> me, Action<TTo, TFrom, FhirConverter> func)
         {
             me.Add((typeof(TTo), typeof(TFrom)), func);
         }

--- a/src/fhir-tool-conversion/Exceptions/UnknownFhirTypeException.cs
+++ b/src/fhir-tool-conversion/Exceptions/UnknownFhirTypeException.cs
@@ -18,6 +18,12 @@ namespace FhirTool.Conversion
             Type = type;
         }
 
+        public UnknownFhirTypeException(Type type, FhirPath path) 
+            : base($"The FHIR type {type.FullName} is unknown. Found at {path.GetFullPath()}")
+        {
+            Type = type;
+        }
+
         public Type Type { get; }
     }
 }

--- a/src/fhir-tool-conversion/Exceptions/UnknownFhirTypeException.cs
+++ b/src/fhir-tool-conversion/Exceptions/UnknownFhirTypeException.cs
@@ -22,8 +22,10 @@ namespace FhirTool.Conversion
             : base($"The FHIR type {type.FullName} is unknown. Found at {path.GetFullPath()}")
         {
             Type = type;
+            Path = path;
         }
 
         public Type Type { get; }
+        public FhirPath Path { get; }
     }
 }

--- a/src/fhir-tool-conversion/FhirConverter.cs
+++ b/src/fhir-tool-conversion/FhirConverter.cs
@@ -94,7 +94,7 @@ namespace FhirTool.Conversion
             {
                 Path = new FhirPath();
                 Path.Push(fromObject.GetType().Name);
-                return ConvertObject<TTo, TFrom>(fromObject);
+                return ConvertElement<TTo, TFrom>(fromObject);
             }
             finally
             {
@@ -102,7 +102,7 @@ namespace FhirTool.Conversion
             }
         }
 
-        internal TTo ConvertObject<TTo,TFrom>(TFrom fromObject)
+        internal TTo ConvertElement<TTo,TFrom>(TFrom fromObject)
             where TFrom : Base
             where TTo : Base
         {
@@ -135,11 +135,11 @@ namespace FhirTool.Conversion
 
             var handledProperties = ConvertTypesWithChanges(targetObject, sourceObject);
             var targetProperties = targetObject.GetType().GetProperties()
-                .Where(prop => Attribute.IsDefined(prop, Converter.GetTargetFhirElementAttribute()));
+                .Where(prop => Attribute.IsDefined(prop, Converter.GetTargetFhirElementAttributeType()));
 
             foreach (var targetProperty in targetProperties)
             {
-                dynamic elementAttribute = targetProperty.GetCustomAttribute(Converter.GetTargetFhirElementAttribute());
+                dynamic elementAttribute = targetProperty.GetCustomAttribute(Converter.GetTargetFhirElementAttributeType());
                 Path.Push(elementAttribute?.Name ?? targetProperty.Name);
 
                 if (handledProperties.Contains(targetProperty.Name)) { Path.Pop(); continue; }

--- a/src/fhir-tool-conversion/FhirPath.cs
+++ b/src/fhir-tool-conversion/FhirPath.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FhirTool.Conversion
+{
+    public class FhirPath
+    {
+        private Stack<string> Path { get; } = new Stack<string>();
+
+        public string GetFullPath()
+        {
+            return string.Join(".", Path.Reverse());
+        }
+
+        public void Push(string pathElem)
+        {
+            Path.Push(pathElem);
+        }
+
+        public void Pop()
+        {
+            Path.Pop();
+        }
+    }
+}

--- a/src/fhir-tool-conversion/FhirPath.cs
+++ b/src/fhir-tool-conversion/FhirPath.cs
@@ -24,5 +24,10 @@ namespace FhirTool.Conversion
         {
             Path.Pop();
         }
+
+        public override string ToString()
+        {
+            return GetFullPath();
+        }
     }
 }


### PR DESCRIPTION
- Changed the order the FhirConverter is sendt to the conversion routines, so that is is last as it is the least important argument.