### PR TITLE
Support for 'download' operation, for dumping resources.

### DIFF
--- a/src/fhir-tool-core/Extensions/BundleExtensions.cs
+++ b/src/fhir-tool-core/Extensions/BundleExtensions.cs
@@ -1,5 +1,7 @@
-﻿using EnsureThat;
-using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using EnsureThat;
+using R3::Hl7.Fhir.Model;
 using System;
 
 namespace FhirTool.Core

--- a/src/fhir-tool-core/Extensions/FhirVersionExtensions.cs
+++ b/src/fhir-tool-core/Extensions/FhirVersionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace FhirTool.Core
+﻿using System.Linq;
+
+namespace FhirTool.Core
 {
     public static class FhirVersionExtensions
     {

--- a/src/fhir-tool-core/Extensions/QuestionnaireExtensions.cs
+++ b/src/fhir-tool-core/Extensions/QuestionnaireExtensions.cs
@@ -1,5 +1,7 @@
-﻿using EnsureThat;
-using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using EnsureThat;
+using R3::Hl7.Fhir.Model;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/fhir-tool-core/Extensions/ResourceExtensions.cs
+++ b/src/fhir-tool-core/Extensions/ResourceExtensions.cs
@@ -1,6 +1,8 @@
-﻿using EnsureThat;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
+﻿extern alias R3;
+
+using EnsureThat;
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Serialization;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/fhir-tool-core/Extensions/ValueSetExtensions.cs
+++ b/src/fhir-tool-core/Extensions/ValueSetExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using System.Text;
 
 namespace FhirTool.Core

--- a/src/fhir-tool-core/FhirDateUtility.cs
+++ b/src/fhir-tool-core/FhirDateUtility.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using System;
 
 namespace FhirTool.Core

--- a/src/fhir-tool-core/FhirToolArguments.cs
+++ b/src/fhir-tool-core/FhirToolArguments.cs
@@ -1,11 +1,15 @@
-﻿using FhirTool.Core.Operations;
-using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using FhirTool.Core.Operations;
+using R3::Hl7.Fhir.Model;
+using System.Collections.Generic;
 
 namespace FhirTool.Core
 {
     public sealed class FhirToolArguments
     {
         public const string GENERATE_OP = "generate";
+        public const string DOWNLOAD_OP = "download";
         public const string UPLOAD_OP = "upload";
         public const string UPLOAD_DEFINITIONS_OP = "upload-definitions";
         public const string BUNDLE_OP = "bundle";
@@ -40,6 +44,9 @@ namespace FhirTool.Core
         public const string CONVERT_FROM_SHORT_ARG = "-cf";
         public const string CONVERT_TO_ARG = "--convert-to";
         public const string CONVERT_TO_SHORT_ARG = "-ct";
+        public const string DOWNLOAD_RESOURCES_ARG = "--resources";
+        public const string FHIR_VERSION = "--fhir-version";
+        public const string KEEP_SERVER_URL = "--keep-server-url";
 
         public const string ENVIRONMENT_SOURCE_ARG = "--environment-source";
         public const string ENVIRONMENT_SOURCE_SHORT_ARG = "-es";
@@ -79,5 +86,8 @@ namespace FhirTool.Core
         public bool SkipValidation { get; set; }
         public string FromFhirVersion { get; set; }
         public string ToFhirVersion { get; set; }
+        public List<string> Resources { get; set; }
+        public FhirVersion? FhirVersion { get; set; }
+        public bool KeepServerUrl { get; set; }
     }
 }

--- a/src/fhir-tool-core/FhirWrappers/BundleWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/BundleWrapper.cs
@@ -1,0 +1,84 @@
+﻿extern alias R3;
+extern alias R4;
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using R3Model = R3::Hl7.Fhir.Model;
+using R4Model = R4::Hl7.Fhir.Model;
+
+namespace FhirTool.Core.FhirWrappers
+{
+    internal class BundleWrapper
+    {
+        public FhirVersion FhirVersion { get; }
+        public R3Model.Bundle R3Bundle { get; }
+        public R4Model.Bundle R4Bundle { get; }
+
+        public BundleWrapper(R3Model.Bundle bundle)
+        {
+            FhirVersion = FhirVersion.R3;
+            R3Bundle = bundle;
+        }
+
+        public BundleWrapper(R4Model.Bundle bundle)
+        {
+            FhirVersion = FhirVersion.R4;
+            R4Bundle = bundle;
+        }
+
+        public IEnumerable<ResourceWrapper> GetResources()
+        {
+            switch(FhirVersion)
+            {
+                case FhirVersion.R3:
+                    return R3Model.BundleExtensions.GetResources(R3Bundle).Select(it => new ResourceWrapper(it));
+                case FhirVersion.R4:
+                    return R4Model.BundleExtensions.GetResources(R4Bundle).Select(it => new ResourceWrapper(it));
+                default:
+                    return default;
+            }
+        }
+
+        internal BundleWrapper UpdateLinks(Uri baseUrl)
+        {
+            switch(FhirVersion)
+            {
+                case FhirVersion.R3:
+                    UådateLinksR3(baseUrl);
+                    break;
+                case FhirVersion.R4:
+                    UpdateLinksR4(baseUrl);
+                    break;
+            }
+
+            return this;
+        }
+
+        private void UådateLinksR3(Uri baseUrl)
+        {
+            foreach(var link in R3Bundle.Link)
+            {
+                link.Url = FixUrl(new Uri(link.Url), baseUrl);
+            }
+        }
+
+        private void UpdateLinksR4(Uri baseUrl)
+        {
+            foreach (var link in R4Bundle.Link)
+            {
+                link.Url = FixUrl(new Uri(link.Url), baseUrl);
+            }
+        }
+
+        private string FixUrl(Uri url, Uri baseUrl)
+        {
+            var urlBuilder = new UriBuilder(new Uri(baseUrl, url.Segments.Last()));
+            urlBuilder.Query = url.Query;
+            urlBuilder.Fragment = url.Fragment;
+
+            return urlBuilder.ToString();
+        }
+    }
+}

--- a/src/fhir-tool-core/FhirWrappers/BundleWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/BundleWrapper.cs
@@ -46,7 +46,7 @@ namespace FhirTool.Core.FhirWrappers
             switch(FhirVersion)
             {
                 case FhirVersion.R3:
-                    UådateLinksR3(baseUrl);
+                    UpdateLinksR3(baseUrl);
                     break;
                 case FhirVersion.R4:
                     UpdateLinksR4(baseUrl);
@@ -56,7 +56,7 @@ namespace FhirTool.Core.FhirWrappers
             return this;
         }
 
-        private void UådateLinksR3(Uri baseUrl)
+        private void UpdateLinksR3(Uri baseUrl)
         {
             foreach(var link in R3Bundle.Link)
             {

--- a/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
@@ -3,6 +3,7 @@ extern alias R4;
 
 using FhirTool.Core.Utils;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 using R3Rest = R3::Hl7.Fhir.Rest;
 using R4Rest = R4::Hl7.Fhir.Rest;
 
@@ -50,29 +51,29 @@ namespace FhirTool.Core.FhirWrappers
             _logger.LogInformation($"{e.RawRequest.Method} {e.RawRequest.Address}");
         }
 
-        internal BundleWrapper Search(string resource)
+        internal async Task<BundleWrapper> SearchAsync(string resource)
         {
             switch (FhirVersion) {
                 case FhirVersion.R3:
-                    var resultR3 = R3Client.Search(resource);
+                    var resultR3 = await R3Client.SearchAsync(resource);
                     return resultR3 != null ? new BundleWrapper(resultR3) : null;
                 case FhirVersion.R4:
-                    var resultR4 = R4Client.Search(resource);
+                    var resultR4 = await R4Client.SearchAsync(resource);
                     return resultR4 != null ? new BundleWrapper(resultR4) : null;
                 default:
                     return default;
             }
         }
 
-        internal BundleWrapper Continue(BundleWrapper bundleWrapper)
+        internal async Task<BundleWrapper> ContinueAsync(BundleWrapper bundleWrapper)
         {
             switch(FhirVersion)
             {
                 case FhirVersion.R3:
-                    var resultR3 = R3Client.Continue(bundleWrapper.R3Bundle);
+                    var resultR3 = await R3Client.ContinueAsync(bundleWrapper.R3Bundle);
                     return resultR3 != null ? new BundleWrapper(resultR3) : null;
                 case FhirVersion.R4:
-                    var resultR4 = R4Client.Continue(bundleWrapper.R4Bundle);
+                    var resultR4 = await R4Client.ContinueAsync(bundleWrapper.R4Bundle);
                     return resultR4 != null ? new BundleWrapper(resultR4) : null;
                 default:
                     return default;

--- a/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
@@ -1,0 +1,82 @@
+﻿extern alias R3;
+extern alias R4;
+
+using FhirTool.Core.Utils;
+using Microsoft.Extensions.Logging;
+using R3Rest = R3::Hl7.Fhir.Rest;
+using R4Rest = R4::Hl7.Fhir.Rest;
+
+namespace FhirTool.Core.FhirWrappers
+{
+    internal class FhirClientWrapper
+    {
+        public FhirVersion FhirVersion { get; }
+        private R3Rest.FhirClient R3Client;
+        private R4Rest.FhirClient R4Client;
+
+        private ILogger _logger;
+
+        internal FhirClientWrapper(string endpoint, ILogger logger, FhirVersion? fhirVersion = null)
+        {
+            _logger = logger;
+
+            if(fhirVersion == null)
+            {
+                R3Client = new R3Rest.FhirClient(endpoint);
+                var meta = R3Client.CapabilityStatement(R3Rest.SummaryType.Text);
+                fhirVersion = FhirVersionUtils.MapStringToFhirVersion(meta.FhirVersion);
+            }
+
+            FhirVersion = fhirVersion.Value;
+            switch(FhirVersion) {
+                case FhirVersion.R4:
+                    R4Client = R4Client ?? new R4Rest.FhirClient(endpoint);
+                    R4Client.OnBeforeRequest += R4Client_OnBeforeRequest;
+                    break;
+                case FhirVersion.R3:
+                    R3Client = R3Client ?? new R3Rest.FhirClient(endpoint);
+                    R3Client.OnBeforeRequest += R3Client_OnBeforeRequest;
+                    break;
+            }
+        }
+
+        private void R3Client_OnBeforeRequest(object sender, R3Rest.BeforeRequestEventArgs e)
+        {
+            _logger.LogInformation($"{e.RawRequest.Method} {e.RawRequest.Address}");
+        }
+
+        private void R4Client_OnBeforeRequest(object sender, R4Rest.BeforeRequestEventArgs e)
+        {
+            _logger.LogInformation($"{e.RawRequest.Method} {e.RawRequest.Address}");
+        }
+
+        internal BundleWrapper Search(string resource)
+        {
+            switch (FhirVersion) {
+                case FhirVersion.R3:
+                    var resultR3 = R3Client.Search(resource);
+                    return resultR3 != null ? new BundleWrapper(resultR3) : null;
+                case FhirVersion.R4:
+                    var resultR4 = R4Client.Search(resource);
+                    return resultR4 != null ? new BundleWrapper(resultR4) : null;
+                default:
+                    return default;
+            }
+        }
+
+        internal BundleWrapper Continue(BundleWrapper bundleWrapper)
+        {
+            switch(FhirVersion)
+            {
+                case FhirVersion.R3:
+                    var resultR3 = R3Client.Continue(bundleWrapper.R3Bundle);
+                    return resultR3 != null ? new BundleWrapper(resultR3) : null;
+                case FhirVersion.R4:
+                    var resultR4 = R4Client.Continue(bundleWrapper.R4Bundle);
+                    return resultR4 != null ? new BundleWrapper(resultR4) : null;
+                default:
+                    return default;
+            }
+        }
+    }
+}

--- a/src/fhir-tool-core/FhirWrappers/ResourceWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/ResourceWrapper.cs
@@ -1,0 +1,58 @@
+﻿extern alias R3;
+extern alias R4;
+
+using R3Model = R3::Hl7.Fhir.Model;
+using R4Model = R4::Hl7.Fhir.Model;
+using R3Serialization = R3::Hl7.Fhir.Serialization;
+using R4Serialization = R4::Hl7.Fhir.Serialization;
+
+namespace FhirTool.Core.FhirWrappers
+{
+    internal class ResourceWrapper
+    {
+        public FhirVersion FhirVersion { get; }
+        private R3Model.Resource R3Resource;
+        private R4Model.Resource R4Resource;
+
+        public ResourceWrapper(R3Model.Resource resource)
+        {
+            FhirVersion = FhirVersion.R3;
+            R3Resource = resource;
+        }
+
+        public ResourceWrapper(R4Model.Resource resource)
+        {
+            FhirVersion = FhirVersion.R4;
+            R4Resource = resource;
+        }
+
+        public string Id
+        {
+            get
+            {
+                switch (FhirVersion)
+                {
+                    case FhirVersion.R3:
+                        return R3Resource.Id;
+                    case FhirVersion.R4:
+                        return R4Resource.Id;
+                    default:
+                        return default;
+                }
+            }
+        }
+
+        public string Serialize()
+        {
+            switch(FhirVersion)
+            {
+                case FhirVersion.R3:
+                    return new R3Serialization.FhirJsonSerializer(new R3Serialization.SerializerSettings { Pretty = true }).SerializeToString(R3Resource);
+                case FhirVersion.R4:
+                    return new R4Serialization.FhirJsonSerializer(new R4Serialization.SerializerSettings { Pretty = true }).SerializeToString(R4Resource);
+                default:
+                    return default;
+            }
+        }
+    }
+}

--- a/src/fhir-tool-core/Operations/BundleResourcesOperation.cs
+++ b/src/fhir-tool-core/Operations/BundleResourcesOperation.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;

--- a/src/fhir-tool-core/Operations/DownloadResourcesOperation.cs
+++ b/src/fhir-tool-core/Operations/DownloadResourcesOperation.cs
@@ -1,0 +1,140 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FhirTool.Core.FhirWrappers;
+
+namespace FhirTool.Core.Operations
+{
+    internal class DownloadResourcesOperation : Operation
+    {
+        private readonly FhirToolArguments _arguments;
+        private readonly ILogger _logger;
+
+        public DownloadResourcesOperation(FhirToolArguments arguments, ILogger logger)
+        {
+            _arguments = arguments;
+            _logger = logger;
+        }
+
+        public override async Task<OperationResultEnum> Execute()
+        {
+            ValidateArguments(_arguments);
+            if (_issues.Any(issue => issue.Severity == IssueSeverityEnum.Error)) return OperationResultEnum.Failed;
+
+            var client = new FhirClientWrapper(_arguments.FhirBaseUrl, _logger, _arguments.FhirVersion);
+            
+            var baseDir = CreateBaseDirectory(new Uri(_arguments.FhirBaseUrl), client.FhirVersion);
+            _logger.LogInformation($"Created local storage at {MakeRelativeToCurrentDirectory(baseDir.FullName)}");
+            DownloadAndStore(client, baseDir);
+
+            return _issues.Any(issue => issue.Severity == IssueSeverityEnum.Error)
+                ? OperationResultEnum.Failed
+                : OperationResultEnum.Succeeded;
+        }
+
+        private DirectoryInfo CreateBaseDirectory(Uri uri, FhirVersion fhirVersion)
+        {
+            var path = Path.Combine(SafeDirectoryName(uri.Host), SafeFilename(fhirVersion.GetFhirVersionAsString()));
+            return Directory.CreateDirectory(path); 
+        }
+
+        private void DownloadAndStore(FhirClientWrapper client, DirectoryInfo baseDir)
+        {
+            foreach (var resourceType in _arguments.Resources)
+            {
+                _logger.LogInformation($"Starting to download resources of type {resourceType}");
+                DownloadAndStoreResource(resourceType, client, baseDir);
+                _logger.LogInformation($"Done downloading resources of type {resourceType}");
+            }
+        }
+
+        private void DownloadAndStoreResource(string resourceType, FhirClientWrapper client, DirectoryInfo baseDir)
+        {
+            var resourceTypeDir = Directory.CreateDirectory(SafeDirectoryName(Path.Combine(baseDir.FullName, resourceType)));
+            var result = client.Search(resourceType);
+            result = _arguments.KeepServerUrl && result != null ? UpdateBundleServerUrl(result) : result;
+            SerializeAndStore(result, resourceTypeDir);
+
+            while(result != null)
+            {
+                result = client.Continue(result);
+                result = _arguments.KeepServerUrl && result != null ? UpdateBundleServerUrl(result) : result;
+                SerializeAndStore(result, resourceTypeDir);
+            }
+        }
+
+        private BundleWrapper UpdateBundleServerUrl(BundleWrapper bundle)
+        {
+            return bundle.UpdateLinks(new Uri(_arguments.FhirBaseUrl));
+        }
+
+        private void SerializeAndStore(BundleWrapper result, DirectoryInfo baseDir)
+        {
+            if (result == null) return;
+            var resources = result.GetResources();
+            _logger.LogInformation($"  Fetched {resources.Count()} resources from server");
+            foreach (var resource in resources)
+            {
+                string serialized = resource.Serialize();
+                Store(resource.Id, serialized, baseDir);
+            }
+        }
+
+        private void Store(string id, string serialized, DirectoryInfo baseDir)
+        {
+            var filename = SafeFilename(string.Join(".", id, "json"));
+            var path = Path.Combine(baseDir.FullName, filename);
+            _logger.LogInformation($"    Storing resource {id} at {MakeRelativeToCurrentDirectory(path)}");
+            File.WriteAllText(path, serialized);
+        }
+
+        private string MakeRelativeToCurrentDirectory(string absolutePath)
+        {
+            var absolute = new Uri(absolutePath);
+            var current = new Uri(Environment.CurrentDirectory);
+            return current.MakeRelativeUri(absolute).ToString();
+        }
+
+        private string SafeDirectoryName(string directoryName)
+        {
+            foreach (var c in Path.GetInvalidPathChars())
+            {
+                directoryName = directoryName.Replace(c, '_');
+            }
+
+            return directoryName;
+        }
+
+        private string SafeFilename(string fileName)
+        {
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                fileName = fileName.Replace(c, '_');
+            }
+
+            return fileName;
+        }
+
+        private void ValidateArguments(FhirToolArguments arguments)
+        {
+            if (string.IsNullOrWhiteSpace(arguments.FhirBaseUrl))
+            {
+                _issues.Add(new Issue
+                {
+                    Details = $"Operation '{FhirToolArguments.DOWNLOAD_OP}' requires argument '{FhirToolArguments.FHIRBASEURL_ARG}' or '{FhirToolArguments.ENVIRONMENT_ARG}'.",
+                    Severity = IssueSeverityEnum.Error,
+                });
+            }
+            if (arguments.Resources == null || !arguments.Resources.Any())
+            {
+                _issues.Add(new Issue
+                {
+                    Details = $"Operation '{FhirToolArguments.DOWNLOAD_OP}' requires argument '{FhirToolArguments.DOWNLOAD_RESOURCES_ARG}'.",
+                    Severity = IssueSeverityEnum.Error,
+                });
+            }
+        }
+    }
+}

--- a/src/fhir-tool-core/Operations/GenerateQuestionnaireOperation.cs
+++ b/src/fhir-tool-core/Operations/GenerateQuestionnaireOperation.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;

--- a/src/fhir-tool-core/Operations/OperationEnum.cs
+++ b/src/fhir-tool-core/Operations/OperationEnum.cs
@@ -10,6 +10,7 @@
         SplitBundle = 5,
         TransferData = 6,
         VerifyValidation = 7,
-        Convert = 8
+        Convert = 8,
+        DownloadResources = 9,
     }
 }

--- a/src/fhir-tool-core/Operations/OperationFactory.cs
+++ b/src/fhir-tool-core/Operations/OperationFactory.cs
@@ -32,6 +32,11 @@ namespace FhirTool.Core.Operations
                         logger: _loggerFactory.CreateLogger<GenerateQuestionnaireOperation>(),
                         operationFactory: this
                     ),
+                OperationEnum.DownloadResources =>
+                    new DownloadResourcesOperation(
+                        arguments: arguments,
+                        logger: _loggerFactory.CreateLogger(typeof(DownloadResourcesOperation))
+                    ),
                 OperationEnum.UploadResource => 
                     new UploadResourceOperation(
                         arguments: arguments,

--- a/src/fhir-tool-core/Operations/SplitBundleOperation.cs
+++ b/src/fhir-tool-core/Operations/SplitBundleOperation.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;

--- a/src/fhir-tool-core/Operations/TransferDataOperation.cs
+++ b/src/fhir-tool-core/Operations/TransferDataOperation.cs
@@ -1,6 +1,8 @@
-﻿using Hl7.Fhir.Model;
-using Hl7.Fhir.Rest;
-using Hl7.Fhir.Serialization;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Rest;
+using R3::Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/fhir-tool-core/Operations/UploadDefinitionsOperation.cs
+++ b/src/fhir-tool-core/Operations/UploadDefinitionsOperation.cs
@@ -1,5 +1,7 @@
-﻿using Hl7.Fhir.Model;
-using Hl7.Fhir.Rest;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;

--- a/src/fhir-tool-core/Operations/UploadResourceOperation.cs
+++ b/src/fhir-tool-core/Operations/UploadResourceOperation.cs
@@ -1,5 +1,7 @@
-﻿using Hl7.Fhir.Model;
-using Hl7.Fhir.Rest;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
 using Microsoft.Extensions.Logging;
 using System.Linq;

--- a/src/fhir-tool-core/Operations/ValidateQuestionnaireOperation.cs
+++ b/src/fhir-tool-core/Operations/ValidateQuestionnaireOperation.cs
@@ -1,4 +1,6 @@
-﻿using Hl7.Fhir.Model;
+﻿extern alias R3;
+
+using R3::Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/fhir-tool-core/QuestionnaireGenerator.cs
+++ b/src/fhir-tool-core/QuestionnaireGenerator.cs
@@ -1,8 +1,10 @@
-﻿using FhirTool.Core.Model;
+﻿extern alias R3;
+
+using FhirTool.Core.Model;
 using FhirTool.Core.Model.FlatFile;
 using FileHelpers.MasterDetail;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/src/fhir-tool-core/SerializationUtility.cs
+++ b/src/fhir-tool-core/SerializationUtility.cs
@@ -1,6 +1,8 @@
-﻿using EnsureThat;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
+﻿extern alias R3;
+
+using EnsureThat;
+using R3::Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
 using System;
@@ -10,6 +12,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
 using Tasks = System.Threading.Tasks;
+using Hl7.Fhir.Model;
 
 namespace FhirTool.Core
 {

--- a/src/fhir-tool-core/Utils/FhirVersionUtils.cs
+++ b/src/fhir-tool-core/Utils/FhirVersionUtils.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+
+namespace FhirTool.Core.Utils
+{
+    public static class FhirVersionUtils
+    {
+        public static FhirVersion? MapStringToFhirVersion(string version)
+        {
+            var majorNumber = version.Split('.').FirstOrDefault();
+            switch (majorNumber)
+            {
+                case "2":
+                    return FhirVersion.R2;
+                case "3":
+                    return FhirVersion.R3;
+                case "4":
+                    return FhirVersion.R4;
+                case "5":
+                    return FhirVersion.R5;
+                default:
+                    return default;
+            }
+        }
+    }
+}

--- a/src/fhir-tool-core/fhir-tool-core.csproj
+++ b/src/fhir-tool-core/fhir-tool-core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,8 +13,33 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="FileHelpers" Version="3.4.1" />
+    <PackageReference Include="Hl7.Fhir.Specification.R4" Version="1.4.0" />
+    <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="1.4.0" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
   </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.STU3.Core'">
+        <Aliases>R3</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.R4.Core'">
+        <Aliases>R4</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.STU3.Specification'">
+        <Aliases>R3</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.R4.Specification'">
+        <Aliases>R4</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/fhir-tool/FhirTool.csproj
+++ b/src/fhir-tool/FhirTool.csproj
@@ -36,4 +36,28 @@
   <ItemGroup>
     <ProjectReference Include="..\fhir-tool-core\fhir-tool-core.csproj" />
   </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.STU3.Core'">
+        <Aliases>R3</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.R4.Core'">
+        <Aliases>R4</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.STU3.Specification'">
+        <Aliases>R3</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Hl7.Fhir.R4.Specification'">
+        <Aliases>R4</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/fhir-tool/FhirToolArguments.cs
+++ b/src/fhir-tool/FhirToolArguments.cs
@@ -1,11 +1,14 @@
-﻿using FhirTool.Configuration;
+﻿extern alias R3;
+
+using FhirTool.Configuration;
 using System.Linq;
 using System.Configuration;
-using Hl7.Fhir.Model;
+using R3::Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using EnsureThat;
 using FhirTool.Core;
 using FhirTool.Core.Operations;
+using FhirTool.Core.Utils;
 
 namespace FhirTool
 {
@@ -25,6 +28,10 @@ namespace FhirTool
                     case FhirToolArguments.GENERATE_OP:
                         if (arguments.Operation != OperationEnum.None) throw new MultipleOperationException(arguments.Operation);
                         arguments.Operation = OperationEnum.GenerateResource;
+                        break;
+                    case FhirToolArguments.DOWNLOAD_OP:
+                        if (arguments.Operation != OperationEnum.None) throw new MultipleOperationException(arguments.Operation);
+                        arguments.Operation = OperationEnum.DownloadResources;
                         break;
                     case FhirToolArguments.UPLOAD_OP:
                         if (arguments.Operation != OperationEnum.None) throw new MultipleOperationException(arguments.Operation);
@@ -144,6 +151,15 @@ namespace FhirTool
                     case FhirToolArguments.CONVERT_TO_ARG:
                     case FhirToolArguments.CONVERT_TO_SHORT_ARG:
                         arguments.ToFhirVersion = FhirVersionInternal.ConvertToFhirVersion(args[i + 1]);
+                        break;
+                    case FhirToolArguments.DOWNLOAD_RESOURCES_ARG:
+                        arguments.Resources = args[i + 1].Split(",").ToList();
+                        break;
+                    case FhirToolArguments.FHIR_VERSION:
+                        arguments.FhirVersion = FhirVersionUtils.MapStringToFhirVersion(args[i + 1]);
+                        break;
+                    case FhirToolArguments.KEEP_SERVER_URL:
+                        arguments.KeepServerUrl = true;
                         break;
                     default:
                         break;


### PR DESCRIPTION
- Dumps resources into a locally mirrored tree structure.
- Dumps from server using any fhir version (currently R3 and R4)
- Supports fhir version discovery by querying the server, but also lets user override with command argument.
- Hack: --keep-server-url argument, to query against the initial server, even though the server returned a result pointing to another server name.