### PR TITLE
Fix stack overflow exception on uploadTransactionOperation.

### DIFF
--- a/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
+++ b/src/fhir-tool-core/FhirWrappers/FhirClientWrapper.cs
@@ -24,11 +24,16 @@ namespace FhirTool.Core.FhirWrappers
         {
             _logger = logger;
 
-            if(fhirVersion == null)
+            if(fhirVersion == FhirVersion.None)
             {
                 R3Client = new R3Rest.FhirClient(endpoint);
                 var meta = R3Client.CapabilityStatement(R3Rest.SummaryType.Text);
                 fhirVersion = FhirVersionUtils.MapStringToFhirVersion(meta.FhirVersion);
+            }
+
+            if(fhirVersion == null)
+            {
+                throw new Exception("Unable to determine FhirVersion used by server. Please specify fhir version");
             }
 
             FhirVersion = fhirVersion.Value;

--- a/src/fhir-tool-core/Operations/UploadTransactionOperation.cs
+++ b/src/fhir-tool-core/Operations/UploadTransactionOperation.cs
@@ -37,6 +37,9 @@ namespace FhirTool.Core.Operations
         [Option('b', "batch-size", Default = 20, MetaValue = "size", HelpText = "number of resources to upload in a transaction")]
         public int BatchSize { get; set; }
 
+        [Option("sleep", HelpText = "Sleep", Default = 0)]
+        public int Sleep { get; set; }
+
         [Value(0, MetaName = "files", MetaValue = "file or dir", HelpText = "list of files/directories to upload", Required = true)]
         public IEnumerable<WithFileOrDirectory> SourceFiles { get; set; }
     }
@@ -73,6 +76,7 @@ namespace FhirTool.Core.Operations
                 {
                     _logger.LogInformation($"Uploading batch with {batch.Count()} entries");
                     await client.TransactionAsync(bundle);
+                    System.Threading.Thread.Sleep(_arguments.Sleep);
                 }
                 catch(Exception e)
                 {
@@ -145,7 +149,7 @@ namespace FhirTool.Core.Operations
 
             foreach (var dir in Directory.EnumerateDirectories(path.Path))
             {
-                var files = FindFilesInDirectory(new WithDirectory(path.Path));
+                var files = FindFilesInDirectory(new WithDirectory(dir));
                 foreach (var file in files)
                 {
                     yield return file;


### PR DESCRIPTION
- Abort when no fhir version can be determined automatically (FhirClientWrapper)
- Support for sleeping between uploading batches