### PR TITLE
Publish fhir-tool as a dotnet tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ x64/
 packages/
 *.ide
 working/
+nupkg
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/src/fhir-tool-core/fhir-tool-core.csproj
+++ b/src/fhir-tool-core/fhir-tool-core.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>FhirTool.Core</RootNamespace>
     <AssemblyName>FhirTool.Core</AssemblyName>
     <LangVersion>8.0</LangVersion>
-    <Version>0.6.1</Version>
+    <Version>1.0.4</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/fhir-tool/.nuspec
+++ b/src/fhir-tool/.nuspec
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <packageTypes>
+      <packageType name="fhir-tool" />
+    </packageTypes>
+  </metadata>
+</package>

--- a/src/fhir-tool/DotnetToolSettings.xml
+++ b/src/fhir-tool/DotnetToolSettings.xml
@@ -1,0 +1,5 @@
+<DotNetCliTool Version="1">
+  <Commands>
+    <Command Name="$name" EntryPoint="$file" Runner="$runner" />
+  </Commands>
+</DotNetCliTool>

--- a/src/fhir-tool/FhirTool.csproj
+++ b/src/fhir-tool/FhirTool.csproj
@@ -5,6 +5,10 @@
     <AssemblyName>fhir-tool</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>false</Deterministic>
+    <PackAsTool>true</PackAsTool>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <ToolCommandName>fhir-tool</ToolCommandName>
+    <Version>1.0.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/fhir-tool/Properties/AssemblyInfo.cs
+++ b/src/fhir-tool/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.1.*")]
-[assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: AssemblyVersion("1.0.4.*")]
+[assembly: AssemblyFileVersion("1.0.4.0")]


### PR DESCRIPTION
Allows easier installation of fhir-tool for end users.
Install on mac, win and linux with command `dotnet tool install -g fhir-tool`.