### PR TITLE
Upgrade tools to be fhir compatible with EHelse.FhirServer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/fhir-tool-core/FhirConverter/Converters/FhirR3ToR4ConversionRoutines.cs
+++ b/src/fhir-tool-core/FhirConverter/Converters/FhirR3ToR4ConversionRoutines.cs
@@ -40,7 +40,6 @@ namespace FhirTool.Conversion.Converters
             Map.Add<TargetModel.Timing.RepeatComponent, SourceModel.Timing.RepeatComponent>(ConvertTimingRepeatComponent);
             Map.Add<TargetModel.ParameterDefinition, SourceModel.ParameterDefinition>(ConvertParameterDefinition);
             Map.Add<TargetModel.Signature, SourceModel.Signature>(ConvertSignature);
-            Map.Add<TargetModel.Range, SourceModel.Range>(ConvertRange);
             Map.Add<TargetModel.Dosage, SourceModel.Dosage>(ConvertDosage);
             Map.Add<TargetModel.Endpoint, SourceModel.Endpoint>(ConvertEndpoint);
             Map.Add<TargetModel.StructureDefinition, SourceModel.StructureDefinition>(ConvertStructureDefinition);
@@ -220,12 +219,6 @@ namespace FhirTool.Conversion.Converters
             }
         }
 
-        private static void ConvertRange(TargetModel.Range to, SourceModel.Range from, FhirConverter converter)
-        {
-            to.High = ConvertQuantityToQuantity(from.High, converter);
-            to.Low = ConvertQuantityToQuantity(from.Low, converter);
-        }
-
         private static void ConvertDosage(TargetModel.Dosage to, SourceModel.Dosage from, FhirConverter converter)
         {
             if (from.Dose != null)
@@ -359,20 +352,6 @@ namespace FhirTool.Conversion.Converters
             return new PositiveInt
             {
                 Value = from.Value,
-                Extension = converter.ConvertList<Extension, Extension>(from.Extension).ToList()
-            };
-        }
-
-        private static TargetModel.Quantity ConvertQuantityToQuantity(SourceModel.Quantity from, FhirConverter converter)
-        {
-            if (from == null) return default;
-
-            return new TargetModel.Quantity
-            {
-                System = from.System,
-                Code = from.Code,
-                Value = from.Value,
-                Unit = from.Unit,
                 Extension = converter.ConvertList<Extension, Extension>(from.Extension).ToList()
             };
         }

--- a/src/fhir-tool-core/fhir-tool-core.csproj
+++ b/src/fhir-tool-core/fhir-tool-core.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FileHelpers" Version="3.5.1" />
-    <PackageReference Include="Hl7.Fhir.Specification.R4" Version="2.0.3" />
-    <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="2.0.3" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.Specification.R4" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="3.4.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="JUST.net" Version="4.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/fhir-tool/FhirTool.csproj
+++ b/src/fhir-tool/FhirTool.csproj
@@ -29,7 +29,7 @@
       <Version>3.5.1</Version>
     </PackageReference>
     <PackageReference Include="Hl7.Fhir.STU3">
-      <Version>2.0.3</Version>
+      <Version>3.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />

--- a/tests/fhir-tool-core-tests/BaseR3ToR4ConversionTests.cs
+++ b/tests/fhir-tool-core-tests/BaseR3ToR4ConversionTests.cs
@@ -202,14 +202,14 @@ namespace FhirTool.Conversion.Tests
         {
             var r3TypeInstance = new R3Model.Ratio
             {
-                Numerator = new R3Model.Quantity
+                Numerator = new Quantity
                 {
                     Value = 103.50m,
                     Unit = "US$",
                     Code = "USD",
                     System = "urn:iso:std:iso:4217"
                 },
-                Denominator = new R3Model.Quantity
+                Denominator = new Quantity
                 {
                     Value = 1,
                     Unit = "day",
@@ -248,21 +248,21 @@ namespace FhirTool.Conversion.Tests
         [Fact]
         public void Can_ConvertElement_R3_Range_To_R4_Range()
         {
-            var r3TypeInstance = new R3Model.Range
+            var r3TypeInstance = new Hl7.Fhir.Model.Range
             {
-                Low = new R3Model.Quantity
+                Low = new Quantity
                 {
                     Value = 1.6m,
                     Unit = "m"
                 },
-                High = new R3Model.Quantity
+                High = new Quantity
                 {
                     Value = 1.9m,
                     Unit = "m"
                 }
             };
             var r4TypeInstance = new FhirConverter(FhirVersion.R4, FhirVersion.R3)
-                .Convert<R4::Hl7.Fhir.Model.Range, R3Model.Range>(r3TypeInstance);
+                .Convert<Hl7.Fhir.Model.Range, Hl7.Fhir.Model.Range >(r3TypeInstance);
             Assert.NotNull(r4TypeInstance);
             Assert.Equal(r3TypeInstance.Low.Value, r4TypeInstance.Low.Value);
             Assert.Equal(r3TypeInstance.Low.Unit, r4TypeInstance.Low.Unit);

--- a/tests/fhir-tool-core-tests/fhir-tool-core-tests.csproj
+++ b/tests/fhir-tool-core-tests/fhir-tool-core-tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.Serialization" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.Serialization" Version="3.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
- EHelse.FhirServer depends on fhir v3.4.0, so need to upgrade this package as well to avoid conflicts.
- Upgrade fhir dependencies to v3.4.0
- Range and Quantity is now part of the common fhir definitions, so no need to convert those anymore.