### PR TITLE
deps: Upgrade Hl7.Fhir.* 4.2.0 -> 4.2.1

### DIFF
--- a/src/fhir-tool-core/fhir-tool-core.csproj
+++ b/src/fhir-tool-core/fhir-tool-core.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FileHelpers" Version="3.5.1" />
-    <PackageReference Include="Hl7.Fhir.Specification.R4" Version="4.2.0" />
-    <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="4.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.0" />
+    <PackageReference Include="Hl7.Fhir.Specification.R4" Version="4.2.1" />
+    <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="4.2.1" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.1" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="JUST.net" Version="4.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/fhir-tool/FhirTool.csproj
+++ b/src/fhir-tool/FhirTool.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FileHelpers" Version="3.5.1" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />

--- a/tests/fhir-tool-core-tests/fhir-tool-core-tests.csproj
+++ b/tests/fhir-tool-core-tests/fhir-tool-core-tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.Serialization" Version="4.2.0" />
+    <PackageReference Include="Hl7.Fhir.Serialization" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Hl7.Fhir.* 4.2.0 packages unintentionally introduced a breaking change, see https://github.com/FirelyTeam/firely-net-sdk/pull/2204